### PR TITLE
Fix syntax warnings for empty documentation

### DIFF
--- a/src/zcl_utesthelp_domconstant_test.clas.abap
+++ b/src/zcl_utesthelp_domconstant_test.clas.abap
@@ -44,7 +44,7 @@ CLASS zcl_utesthelp_domconstant_test DEFINITION
     "! </p>
     "! @parameter i_variable   | <p class="shorttext synchronized">Instance variable of the constant class</p>
     "! <p>Does not have to be bound.</p>
-    "! @parameter rv_result |
+    "! @parameter rv_result | <p class="shorttext synchronized"></p>
     METHODS determine_class_name_from_type
       IMPORTING
         i_variable       TYPE data

--- a/src/zcl_utesthelp_test_double_util.clas.abap
+++ b/src/zcl_utesthelp_test_double_util.clas.abap
@@ -21,8 +21,8 @@ CLASS zcl_utesthelp_test_double_util DEFINITION
     "! <p>
     "! Please see the documentation of method CREATE in CL_ABAP_TESTDOUBLE for more general details.
     "! </p>
-    "! @parameter i_typed_variable |
-    "! @parameter ro_result |
+    "! @parameter i_typed_variable | <p class="shorttext synchronized"></p>
+    "! @parameter ro_result | <p class="shorttext synchronized">
     CLASS-METHODS create_test_double
       IMPORTING
         i_typed_variable TYPE data


### PR DESCRIPTION
Fix the syntax warning "Empty documentation is not allowed" introduced with S/4.